### PR TITLE
[BC BREAK] ErrorInterface::transfer() interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
             "BEAR\\Sunday\\": "src/"
         }
     },
+    "autoload-dev": {
+        "files": ["tests/Fake/functions.php"]
+    },
     "extra": {
         "branch-alias": {
             "dev-develop-2": "1.0.x-dev"

--- a/docs/demo/MyVendor/HelloWorld/www/index.php
+++ b/docs/demo/MyVendor/HelloWorld/www/index.php
@@ -25,8 +25,5 @@ try {
     $page()->transfer($app->responder, $_SERVER);
 
 } catch (\Exception $e) {
-    $code = $e->getCode() ?: 500;
-    http_response_code($code);
-    echo $code;
-    error_log($e);
+    $app->error->handle($e, $request)->transfer();
 }

--- a/src/Extension/Error/ErrorInterface.php
+++ b/src/Extension/Error/ErrorInterface.php
@@ -6,16 +6,22 @@
  */
 namespace BEAR\Sunday\Extension\Error;
 
-use BEAR\Resource\ResourceObject;
 use BEAR\Sunday\Extension\Router\RouterMatch as Request;
 
 interface ErrorInterface
 {
     /**
+     * Handle exception
+     *
      * @param \Exception $e
      * @param Request    $request
      *
-     * @return ResourceObject
+     * @return $this
      */
     public function handle(\Exception $e, Request $request);
+
+    /**
+     * Error page transfer
+     */
+    public function transfer();
 }

--- a/tests/Fake/Provide/Error/FakeVndError.php
+++ b/tests/Fake/Provide/Error/FakeVndError.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * test header function is taken from Aura.Web
+ * @see https://github.com/auraphp/Aura.Web/blob/a1a4e45d14b21d40d716d341b78a050e1905cc05/tests/unit/src/FakeResponseSender.php
+ */
+namespace BEAR\Sunday\Provide\Error;
+
+use BEAR\Resource\ResourceObject;
+
+require_once __DIR__ . '/header.php';
+
+class FakeVndError extends VndError
+{
+    public static $code = [];
+    public static $headers = [];
+    public static $content;
+
+    public static function reset()
+    {
+        static::$code = [];
+        static::$headers = [];
+        static::$content = null;
+    }
+
+    public function transfer()
+    {
+        ob_start();
+        parent::transfer();
+        $body =  ob_get_clean();
+        self::$content = $body;
+    }
+}

--- a/tests/Fake/Provide/Error/header.php
+++ b/tests/Fake/Provide/Error/header.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BEAR\Sunday\Provide\Error;
+
+function header(
+    $string,
+    $replace = true,
+    $http_response_code = null
+) {
+    FakeVndError::$headers = func_get_args();
+}

--- a/tests/Fake/Provide/Error/http_response_code.php
+++ b/tests/Fake/Provide/Error/http_response_code.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BEAR\Sunday\Provide\Error;
+
+
+function http_response_code($int) {
+    FakeVndError::$code = func_get_args();
+}

--- a/tests/Fake/functions.php
+++ b/tests/Fake/functions.php
@@ -1,0 +1,5 @@
+<?php
+
+require __DIR__ . '/Provide/Transfer/header.php';
+require __DIR__ . '/Provide/Error/header.php';
+require __DIR__ . '/Provide/Error/http_response_code.php';


### PR DESCRIPTION
ErrorInterface::handle return itself, not resource object.
error page object is not expose, transfer() use it.